### PR TITLE
Remove CardView to fix error on kk an jb devices

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -13,7 +13,7 @@
         android:orientation="vertical"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
-    <android.support.v7.widget.CardView
+    <LinearLayout
         android:focusableInTouchMode="true"
         android:layout_margin="16dp"
         android:layout_width="match_parent"
@@ -43,7 +43,7 @@
         android:layout_height="wrap_content"
         android:text="FIND USER"/>
         </LinearLayout>
-    </android.support.v7.widget.CardView>
+    </LinearLayout>
 
 </LinearLayout>
 </ScrollView>


### PR DESCRIPTION
Had this error on 4.0.3 to 4.4 devices when a Card-View was used
               ` java.lang.IllegalArgumentException: radius must be > 0`
Fixed by removing any Card Views from Xml